### PR TITLE
Refactor chat hooks and schedule logic

### DIFF
--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -1,9 +1,10 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
 import { ChatMessage, N8nChatHistory } from '@/types/chat';
 import { parseMessage } from '@/utils/chatUtils';
+import { fetchChatHistory, subscribeToChat } from '@/lib/chatService';
+import { logger } from '@/utils/logger';
 
 export function useChatMessages(selectedChat: string | null) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -13,41 +14,16 @@ export function useChatMessages(selectedChat: string | null) {
   const fetchMessages = useCallback(async (conversationId: string) => {
     try {
       setLoading(true);
-      console.log(`Fetching messages for conversation: ${conversationId}`);
-      
-      const { data: historyData, error: historyError } = await supabase
-        .from('n8n_chat_histories')
-        .select('*')
-        .eq('session_id', conversationId)
-        .order('id', { ascending: true });
-      
-      if (historyError) {
-        console.error('Error fetching chat history:', historyError);
-        throw historyError;
-      }
-      
-      console.log(`Fetched ${historyData?.length || 0} history records`);
-      console.log('Sample record with hora:', historyData && historyData.length > 0 ? historyData[0] : 'No records');
-      
-      let allMessages: ChatMessage[] = [];
-      
-      if (historyData && historyData.length > 0) {
-        historyData.forEach((chatHistory: N8nChatHistory) => {
-          console.log(`Processing message with hora: ${chatHistory.hora}`);
-          const parsedMessages = parseMessage(chatHistory);
-          if (parsedMessages.length > 0) {
-            allMessages = [...allMessages, ...parsedMessages];
-          }
-        });
-        
-        setMessages(allMessages);
-        console.log("Fetched and processed messages:", allMessages.length);
-      } else {
-        console.log("No messages found for this conversation");
-        setMessages([]);
-      }
+      logger.debug(`Fetching messages for conversation: ${conversationId}`);
+
+      const historyData = await fetchChatHistory(conversationId);
+
+      const allMessages = historyData.flatMap(parseMessage);
+
+      setMessages(allMessages);
+      logger.debug("Fetched and processed messages:", allMessages.length);
     } catch (error) {
-      console.error('Error fetching messages:', error);
+      logger.error('Error fetching messages:', error);
       toast({
         title: "Erro ao carregar mensagens",
         description: "Ocorreu um erro ao carregar as mensagens.",
@@ -61,38 +37,18 @@ export function useChatMessages(selectedChat: string | null) {
   // Set up subscription for real-time message updates for the current chat
   useEffect(() => {
     if (!selectedChat) return;
-    
-    console.log(`Setting up realtime listener for specific chat messages: ${selectedChat}`);
-    
-    const subscription = supabase
-      .channel(`chat_messages_${selectedChat}`)
-      .on('postgres_changes', 
-        { 
-          event: 'INSERT', 
-          schema: 'public', 
-          table: 'n8n_chat_histories',
-          filter: `session_id=eq.${selectedChat}`
-        }, 
-        (payload) => {
-          console.log('New message received in current chat via realtime:', payload);
-          
-          // Process the new message
-          const chatHistory = payload.new as N8nChatHistory;
-          console.log('New message hora field:', chatHistory.hora);
-          const newMessages = parseMessage(chatHistory);
-          
-          if (newMessages.length > 0) {
-            console.log("Adding new messages from realtime:", newMessages);
-            setMessages(prevMessages => [...prevMessages, ...newMessages]);
-          }
-        }
-      )
-      .subscribe();
-    
-    console.log(`Realtime subscription created for chat: ${selectedChat}`);
-      
+
+    logger.debug(`Setting up realtime listener for chat: ${selectedChat}`);
+
+    const subscription = subscribeToChat(selectedChat, (chatHistory: N8nChatHistory) => {
+      const newMessages = parseMessage(chatHistory);
+      if (newMessages.length > 0) {
+        setMessages(prev => [...prev, ...newMessages]);
+      }
+    });
+
     return () => {
-      console.log(`Cleaning up realtime subscription for chat: ${selectedChat}`);
+      logger.debug(`Cleaning up realtime subscription for chat: ${selectedChat}`);
       subscription.unsubscribe();
     };
   }, [selectedChat]);
@@ -108,7 +64,7 @@ export function useChatMessages(selectedChat: string | null) {
   }, [selectedChat, fetchMessages]);
 
   const handleNewMessage = (message: ChatMessage) => {
-    console.log("Adding new message to local state:", message);
+    logger.debug("Adding new message to local state:", message);
     setMessages(currentMessages => [...currentMessages, message]);
   };
 

--- a/src/lib/chatService.ts
+++ b/src/lib/chatService.ts
@@ -1,0 +1,35 @@
+import { supabase } from '@/integrations/supabase/client';
+import { N8nChatHistory } from '@/types/chat';
+
+export async function fetchChatHistory(conversationId: string) {
+  const { data, error } = await supabase
+    .from('n8n_chat_histories')
+    .select('*')
+    .eq('session_id', conversationId)
+    .order('id', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data || []) as N8nChatHistory[];
+}
+
+export function subscribeToChat(
+  conversationId: string,
+  onInsert: (chatHistory: N8nChatHistory) => void
+) {
+  return supabase
+    .channel(`chat_messages_${conversationId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'n8n_chat_histories',
+        filter: `session_id=eq.${conversationId}`,
+      },
+      (payload) => onInsert(payload.new as N8nChatHistory)
+    )
+    .subscribe();
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,23 @@
+export interface Logger {
+  debug(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+class ConsoleLogger implements Logger {
+  debug(...args: unknown[]) {
+    if (import.meta.env.DEV) console.debug(...args);
+  }
+  info(...args: unknown[]) {
+    if (import.meta.env.DEV) console.info(...args);
+  }
+  warn(...args: unknown[]) {
+    if (import.meta.env.DEV) console.warn(...args);
+  }
+  error(...args: unknown[]) {
+    if (import.meta.env.DEV) console.error(...args);
+  }
+}
+
+export const logger: Logger = new ConsoleLogger();


### PR DESCRIPTION
## Summary
- create reusable logger utility
- add chatService to abstract Supabase calls
- refactor `useChatMessages` to use chatService and logger
- refactor `useScheduleData` for clarity and logging

## Testing
- `npm run lint` *(fails: cannot find package and shows lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858d46ef194832b817c54cc6a0d311e